### PR TITLE
feat: add wot-demo as a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,20 @@ npx create-uni@latest --info
 
 | 配置项 | 参数 | 别名 | 可选值 |
 |  :---: | :---: | :---: | :---: |
-| Template | —— | t | vitesse |
+| Template | —— | t | 见[模板列表](#模板列表) |
 | TypeScript | ts | —— | —— |
 | Plugin | pluginList | p | 见[插件列表](#插件列表) |
 | Module | moduleList | m | 见[模块列表](#模块列表) |
 | UI | ui | u | 见[组件列表](#组件列表) |
 | Eslint | eslint | e | —— |
 | info | info |  —— | all |
+
+#### 📦模板列表
+
+| 模板名 | 描述 | 参数名 |
+| :---: | :---: | :---: |
+| [vitesse-uni-app](https://github.com/uni-helper/vitesse-uni-app) | 由 Vite & uni-app 驱动的跨端快速启动模板   | vitesse |
+| [wot-demo](https://github.com/Moonofweisheng/wot-demo) | 基于 vitesse-uni-app 的 wot-design-uni 快速起手demo |  wot    |
 
 #### 📦插件列表
 

--- a/src/question/template/templateDate.ts
+++ b/src/question/template/templateDate.ts
@@ -12,4 +12,14 @@ export const templateList: TemplateList[] = [
       },
     },
   },
+  {
+    title: `wot-demo`,
+    description: `由${link(green('Wot Design Uni'), 'https://github.com/Moonofweisheng/wot-demo')}提供的基于vitesse-uni-app的快速启动模板`,
+    value: {
+      type: 'wot',
+      url: {
+        github: 'https://github.com/Moonofweisheng/wot-demo.git',
+      },
+    },
+  },
 ]


### PR DESCRIPTION
### Description 描述
[wot-demo](https://github.com/Moonofweisheng/wot-demo)是基于[vitesse-uni-app](https://github.com/uni-helper/vitesse-uni-app)的wot-design-uni组件库的快速上手模板，期望可以添加到create-uni中，方便wot-design-uni组件库的使用者快速创建一个项目，





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new template titled `wot-demo` for enhanced user options, including a description and a link to its GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->