### PR TITLE
docs: 更新模板列表中的wot-starter相关信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ npx @create-uni/info@latest
 |                                       模板名                                      |                      描述                      |         参数名        |
 | :----------------------------------------------------------------------------: | :------------------------------------------: | :----------------: |
 |        [vitesse-uni-app](https://github.com/uni-helper/vitesse-uni-app)        |         由 Vite & uni-app 驱动的跨端快速启动模板         |       vitesse      |
-|             [wot-demo](https://github.com/Moonofweisheng/wot-demo)             | 基于 vitesse-uni-app 的 wot-design-uni 快速起手demo |      wot-demo      |
-| [wot-starter-retail](https://github.com/Moonofweisheng/wot-starter-retail.git) |        基于Wot Design Uni的uni-app零售行业模板        | wot-starter-retail |
+|             [wot-starter](https://github.com/wot-ui/wot-starter)             | 基于 vitesse-uni-app 的 wot-ui 快速起手demo |      wot-starter      |
+| [wot-starter-retail](https://github.com/wot-ui/wot-starter-retail) |        基于 wot-ui 的uni-app零售行业模板        | wot-starter-retail |
 |                   [unisave](https://github.com/sunpm/unisave)                  |    拥抱 web 开发，拯救 uniapp。适配所有(app、mp、web)平台    |       unisave      |
 |                   [tmui 3.2](https://tmui.design)                  |    优质Vue3 TS Pinia Vite跨端组件库   |       tmui32      |
 

--- a/packages/core/src/question/template/template.data.ts
+++ b/packages/core/src/question/template/template.data.ts
@@ -14,12 +14,12 @@ export const templateList: TemplateList[] = [
   },
   {
     label: `wot`,
-    description: `由${green('Wot UI')}提供的基于vitesse-uni-app的快速启动模板`,
+    description: `由${green('Wot UI')}提供的基于 vitesse-uni-app 的快速启动模板`,
     value: 'wot',
     list: [
       {
         label: `wot-starter`,
-        description: `由${rgb(77, 128, 240)('Wot UI')}提供的基于vitesse-uni-app的快速启动模板`,
+        description: `由${rgb(77, 128, 240)('Wot UI')}提供的基于 vitesse-uni-app 的快速启动模板`,
         value: 'wot-starter',
         url: {
           github: 'https://github.com/wot-ui/wot-starter.git',
@@ -29,10 +29,10 @@ export const templateList: TemplateList[] = [
       },
       {
         label: 'wot-starter-retail',
-        description: `基于${rgb(77, 128, 240)('Wot UI')}的uni-app零售行业模板`,
+        description: `基于${rgb(77, 128, 240)('Wot UI')}的 uni-app 零售行业模板`,
         value: 'wot-starter-retail',
         url: {
-          github: 'https://github.com/Moonofweisheng/wot-starter-retail.git',
+          github: 'https://github.com/wot-ui/wot-starter-retail.git',
         },
         playground: 'https://starter-retail.wot-ui.cn/',
       },
@@ -40,7 +40,7 @@ export const templateList: TemplateList[] = [
   },
   {
     label: `unisave`,
-    description: `拥抱 web 开发，${lightMagenta('拯救')}uniapp。适配所有(app、mp、web)平台`,
+    description: `拥抱 web 开发，${lightMagenta('拯救')}uniapp。适配所有 (app、mp、web) 平台`,
     value: 'unisave',
     url: {
       github: 'https://github.com/sunpm/unisave.git',
@@ -50,7 +50,7 @@ export const templateList: TemplateList[] = [
   },
   {
     label: `tmui3.2`,
-    description: `优质Vue3 TS Pinia Vite跨端组件库`,
+    description: `优质 Vue3 TS Pinia Vite 跨端组件库`,
     value: 'tmui32',
     url: {
       gitee: 'https://gitee.com/LYTB/tmui-design.git',

--- a/packages/core/src/question/template/template.data.ts
+++ b/packages/core/src/question/template/template.data.ts
@@ -14,26 +14,27 @@ export const templateList: TemplateList[] = [
   },
   {
     label: `wot`,
-    description: `由${green('Wot Design Uni')}提供的基于vitesse-uni-app的快速启动模板`,
+    description: `由${green('Wot UI')}提供的基于vitesse-uni-app的快速启动模板`,
     value: 'wot',
     list: [
       {
-        label: `wot-demo`,
-        description: `由${rgb(77, 128, 240)('Wot Design Uni')}提供的基于vitesse-uni-app的快速启动模板`,
-        value: 'wot-demo',
+        label: `wot-starter`,
+        description: `由${rgb(77, 128, 240)('Wot UI')}提供的基于vitesse-uni-app的快速启动模板`,
+        value: 'wot-starter',
         url: {
-          github: 'https://github.com/Moonofweisheng/wot-demo.git',
+          github: 'https://github.com/wot-ui/wot-starter.git',
         },
-        playground: 'https://wot-demo.netlify.app/',
+        website: 'https://starter.wot-ui.cn/',
+        playground: 'https://starter-demo.wot-ui.cn/',
       },
       {
         label: 'wot-starter-retail',
-        description: `基于${rgb(77, 128, 240)('Wot Design Uni')}的uni-app零售行业模板`,
+        description: `基于${rgb(77, 128, 240)('Wot UI')}的uni-app零售行业模板`,
         value: 'wot-starter-retail',
         url: {
           github: 'https://github.com/Moonofweisheng/wot-starter-retail.git',
         },
-        playground: 'https://moonofweisheng.github.io/wot-starter-retail/',
+        playground: 'https://starter-retail.wot-ui.cn/',
       },
     ],
   },


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

将wot-demo更新为wot-starter，并更新相关描述和链接，更新wot-starter-retail的描述和链接，更新wot-ui相关信息。
<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues
无
### Additional context 额外上下文
[wot-demo](https://github.com/wot-ui/wot-starter)和[wot-starter-retail](https://github.com/wot-ui/wot-starter-retail)迁移到[wot-ui](https://github.com/wot-ui)组织下，同时wot-demo更换名称为wot-starter。

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced “wot-demo” with “wot-starter” in template options; updated labels, descriptions, repo links, and playground URLs.
  * Introduced a website field for Wot templates and refreshed the wot-starter-retail playground URL.

* **Documentation**
  * Updated README template list: swapped in “wot-starter,” updated retail template link/description to Wot UI, and standardized template URLs to current Wot UI resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->