### PR TITLE
fix(core): 修复 uni-uni 与 uni-echarts 自动导入冲突

### DIFF
--- a/packages/core/template/UI/uni/vite.config.js.data.mjs
+++ b/packages/core/template/UI/uni/vite.config.js.data.mjs
@@ -1,6 +1,14 @@
 export default function getData({ oldData, utils }) {
-  const hasRootPlugin = oldData.plugins.some(plugin => plugin.id === 'root')
-  const resolverOptions = hasRootPlugin ? '{ exclude: \'UniKuAppRoot\' }' : ''
+  const excludes = []
+
+  if (oldData.plugins.some(plugin => plugin.id === 'root')) {
+    excludes.push('UniKuAppRoot')
+  }
+  if (oldData.plugins.some(plugin => plugin.id === 'uni-echarts')) {
+    excludes.push('UniEcharts')
+  }
+
+  const resolverOptions = excludes.length > 0 ? `{ exclude: /${excludes.join('|')}/ }` : ''
 
   const autoImportUniUiPlugin = {
     id: 'uni-ui',


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

修复 `uni-uni` 与 `uni-echarts` 自动导入冲突。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically enables UniKuAppRoot and uni-echarts integrations when detected, reducing manual setup.
- Bug Fixes
  - Improves module resolution by consolidating multiple exclusions into a single, regex-based list, minimizing conflicts.
- Refactor
  - Streamlines configuration logic to handle multiple exclusions and generate a unified resolver option for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->